### PR TITLE
Fixing biblatex warnings

### DIFF
--- a/VUMIFPSmagistrinis.cls
+++ b/VUMIFPSmagistrinis.cls
@@ -76,7 +76,7 @@
 
 % Nustatomas bibliografijos stilius
 \RequirePackage[
-    alldates=iso8601,
+    alldates=iso,
     autolang=other,
     backend=biber,
     sortcites=true,
@@ -86,6 +86,7 @@
     maxalphanames=3,
     maxnames=9,
     minnames=4,
+    seconds=true,
 ]{biblatex}
 \RequirePackage[style=lithuanian]{csquotes}
 

--- a/bibliografija.bib
+++ b/bibliografija.bib
@@ -1,5 +1,5 @@
-Plačiau apie šaltinių tipus ir jų atributus:
-http://mirror.datacenter.by/pub/mirrors/CTAN/macros/latex/contrib/biblatex/doc/biblatex.pdf#subsection.2.1
+% Plačiau apie šaltinių tipus ir jų atributus:
+% http://mirror.datacenter.by/pub/mirrors/CTAN/macros/latex/contrib/biblatex/doc/biblatex.pdf#subsection.2.1
 
 @article{PvzStraipsnLt,
     author={A. Pavardenis and B. Pavardonis and C. Pavardauskas},


### PR DESCRIPTION
Fixing biblatex warnings:
```
Package biblatex Warning: 'iso8601' date format specifier is deprecated. Use 'iso' instead.
Package biblatex Warning: Conflicting options. 'date=iso' requires 'seconds=true'.
Package biblatex Warning: '\mkdaterangeiso8601' is deprecated. Please use '\mkdaterangeiso'.
BibTeX subsystem: warning: 148 characters of junk seen at toplevel
```